### PR TITLE
Decouple SpotifyTrack from Song

### DIFF
--- a/backend/app/controllers/api/v1/songs_controller.rb
+++ b/backend/app/controllers/api/v1/songs_controller.rb
@@ -1,8 +1,30 @@
 class Api::V1::SongsController < ApplicationController
 
     def create
+        # Note: SpotifyTrack is a parent object of Song. Normally, a parent object would accept_nested_attributes_for 
+        #       the child object to create the dependent child. However, due to the fact that we do not want to create a 
+        #       SpotifyTrack unless there are indeed Song objects linked to it for space and practical reasons, we will
+        #       either find or create the parent SpotifyTrack here before creating the Song.
+
+        # Strong params
+        song_params, spotify_track_params = create_params
+
+        # Find the existing SpotifyTrack with the given ID, or initialize a new one (not yet persisted).
+        spotify_track = SpotifyTrack.find_or_initialize_by(spotify_id: spotify_track_params[:spotify_id]) do |st|
+            st.title = spotify_track_params[:title]
+            st.artist = spotify_track_params[:artist]
+            st.artwork_url = spotify_track_params[:artwork_url]
+        end
+
+        # Make sure the spotify track is valid before proceeding. Don't persist yet due to the fact that we don't know if the Song is valid.
+        if !spotify_track.valid?
+            render json: { error: 'Failed to create song', messages: spotify_track.errors.full_messages }, status: :bad_request
+
+        # Create the Song and associate it with the SpotifyTrack and User
         song = Song.new(song_params)
-        song.user_id = @user.id
+        song.spotify_track = spotify_track
+        song.user = @user
+        
         if song.save
             render json: song, status: :created
         else
@@ -12,12 +34,17 @@ class Api::V1::SongsController < ApplicationController
     
     private
 
-    def song_params
-        params.require(:song).permit(
-            :spotify_id, :title, :artist, :artwork_url,  # Spotify data
+    def create_params
+        song_params, spotify_track_params = params.require([:song, :spotify_track])
+        
+        permitted_song_params = song_params.permit(
             :guitar_type, :capo, :notes,  # User generated data
             sections_attributes: [:id, :name, :chords, :strumming, :display_order, :_destroy]  # Associations data
         )
+
+        permitted_spotify_track_params = spotify_track_params.permit(:title, :artist, :spotify_id, :artwork_url)
+
+        return song_params, spotify_track_params
     end
 
 end

--- a/backend/app/controllers/api/v1/songs_controller.rb
+++ b/backend/app/controllers/api/v1/songs_controller.rb
@@ -19,6 +19,7 @@ class Api::V1::SongsController < ApplicationController
         # Make sure the spotify track is valid before proceeding. Don't persist yet due to the fact that we don't know if the Song is valid.
         if !spotify_track.valid?
             render json: { error: 'Failed to create song', messages: spotify_track.errors.full_messages }, status: :bad_request
+        end
 
         # Create the Song and associate it with the SpotifyTrack and User
         song = Song.new(song_params)
@@ -44,7 +45,7 @@ class Api::V1::SongsController < ApplicationController
 
         permitted_spotify_track_params = spotify_track_params.permit(:title, :artist, :spotify_id, :artwork_url)
 
-        return song_params, spotify_track_params
+        return permitted_song_params, permitted_spotify_track_params
     end
 
 end

--- a/backend/app/models/song.rb
+++ b/backend/app/models/song.rb
@@ -5,4 +5,8 @@ class Song < ApplicationRecord
     has_many :sections
 
     accepts_nested_attributes_for :sections 
+
+    # Validations
+    validates :spotify_track, uniqueness: { scope: :user, message: "already has a song created by this user"  }
+
 end

--- a/backend/app/models/song.rb
+++ b/backend/app/models/song.rb
@@ -1,10 +1,8 @@
 class Song < ApplicationRecord
     # Associations
     belongs_to :user
+    belongs_to :spotify_track
     has_many :sections
 
-    accepts_nested_attributes_for :sections
-
-    # Validations
-    validates :title, :artist, :spotify_id, presence: true 
+    accepts_nested_attributes_for :sections 
 end

--- a/backend/app/models/spotify_track.rb
+++ b/backend/app/models/spotify_track.rb
@@ -1,0 +1,2 @@
+class SpotifyTrack < ApplicationRecord
+end

--- a/backend/app/models/spotify_track.rb
+++ b/backend/app/models/spotify_track.rb
@@ -1,2 +1,7 @@
 class SpotifyTrack < ApplicationRecord
+    # Associations
+    has_many :songs
+
+    # Validations
+    validates :title, :artist, :spotify_id, presence: true
 end

--- a/backend/app/serializers/song_serializer.rb
+++ b/backend/app/serializers/song_serializer.rb
@@ -1,4 +1,5 @@
 class SongSerializer < ActiveModel::Serializer
-    attributes :id, :spotify_id, :title, :artist, :artwork_url, :guitar_type, :capo, :notes, :user_id
+    attributes :id, :guitar_type, :capo, :notes, :user_id
     has_many :sections
+    has_one :spotify_track
 end

--- a/backend/app/serializers/song_serializer.rb
+++ b/backend/app/serializers/song_serializer.rb
@@ -1,5 +1,5 @@
 class SongSerializer < ActiveModel::Serializer
     attributes :id, :guitar_type, :capo, :notes, :user_id
+    belongs_to :spotify_track
     has_many :sections
-    has_one :spotify_track
 end

--- a/backend/app/serializers/spotify_track_serializer.rb
+++ b/backend/app/serializers/spotify_track_serializer.rb
@@ -1,0 +1,3 @@
+class SpotifyTrackSerializer < ActiveModel::Serializer
+  attributes :id, :title, :artist, :spotify_id, :artwork_url
+end

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -1,5 +1,6 @@
 Rails.application.routes.draw do
 
+  resources :spotify_tracks
   # Namespace endpoints to /api/v1
   namespace :api do
     namespace :v1 do

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -1,6 +1,5 @@
 Rails.application.routes.draw do
 
-  resources :spotify_tracks
   # Namespace endpoints to /api/v1
   namespace :api do
     namespace :v1 do

--- a/backend/db/migrate/20200512164856_create_spotify_tracks.rb
+++ b/backend/db/migrate/20200512164856_create_spotify_tracks.rb
@@ -1,0 +1,15 @@
+class CreateSpotifyTracks < ActiveRecord::Migration[6.0]
+  def change
+    create_table :spotify_tracks do |t|
+      t.string :title, null: false
+      t.string :artist, null: false
+      t.string :spotify_id, null: false
+      t.string :artwork_url
+
+      t.timestamps
+    end
+
+    # Unique on spotify_id
+    add_index :spotify_tracks, :spotify_id, unique: true
+  end
+end

--- a/backend/db/migrate/20200512165059_create_songs.rb
+++ b/backend/db/migrate/20200512165059_create_songs.rb
@@ -2,19 +2,16 @@ class CreateSongs < ActiveRecord::Migration[6.0]
   def change
     # Create the table
     create_table :songs do |t|
-      t.string :title, null: false
-      t.string :artist, null: false
       t.string :guitar_type
       t.integer :capo
       t.text :notes
-      t.string :spotify_id, null: false
-      t.string :artwork_url
       t.references :user, null: false, foreign_key: true
+      t.references :spotify_track, null: false, foreign_key: true
 
       t.timestamps
     end
 
-    # Unique on (user_id, spotify_id)
-    add_index :songs, [:user_id, :spotify_id], unique: true
+    # Unique on (user_id, spotify_track_id)
+    add_index :songs, [:user_id, :spotify_track_id], unique: true
   end
 end

--- a/backend/db/migrate/20200518213054_create_sections.rb
+++ b/backend/db/migrate/20200518213054_create_sections.rb
@@ -15,3 +15,6 @@ class CreateSections < ActiveRecord::Migration[6.0]
     add_index :sections, [:song_id, :display_order], unique: true
   end
 end
+
+
+# Original: 20200512165059

--- a/backend/db/migrate/20200518213054_create_sections.rb
+++ b/backend/db/migrate/20200518213054_create_sections.rb
@@ -15,6 +15,3 @@ class CreateSections < ActiveRecord::Migration[6.0]
     add_index :sections, [:song_id, :display_order], unique: true
   end
 end
-
-
-# Original: 20200512165059

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_12_165059) do
+ActiveRecord::Schema.define(version: 2020_05_18_213054) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -28,18 +28,26 @@ ActiveRecord::Schema.define(version: 2020_05_12_165059) do
   end
 
   create_table "songs", force: :cascade do |t|
-    t.string "title", null: false
-    t.string "artist", null: false
     t.string "guitar_type"
     t.integer "capo"
     t.text "notes"
-    t.string "spotify_id", null: false
-    t.string "artwork_url"
     t.bigint "user_id", null: false
+    t.bigint "spotify_track_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.index ["user_id", "spotify_id"], name: "index_songs_on_user_id_and_spotify_id", unique: true
+    t.index ["spotify_track_id"], name: "index_songs_on_spotify_track_id"
+    t.index ["user_id", "spotify_track_id"], name: "index_songs_on_user_id_and_spotify_track_id", unique: true
     t.index ["user_id"], name: "index_songs_on_user_id"
+  end
+
+  create_table "spotify_tracks", force: :cascade do |t|
+    t.string "title", null: false
+    t.string "artist", null: false
+    t.string "spotify_id", null: false
+    t.string "artwork_url"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["spotify_id"], name: "index_spotify_tracks_on_spotify_id", unique: true
   end
 
   create_table "users", force: :cascade do |t|
@@ -53,5 +61,6 @@ ActiveRecord::Schema.define(version: 2020_05_12_165059) do
   end
 
   add_foreign_key "sections", "songs"
+  add_foreign_key "songs", "spotify_tracks"
   add_foreign_key "songs", "users"
 end

--- a/backend/db/seeds.rb
+++ b/backend/db/seeds.rb
@@ -5,16 +5,21 @@ DatabaseCleaner.clean
 # Create a fake user
 user = User.create!(first_name: 'John', last_name: 'Doe', email: 'johndoe@fake.com', password: 'password')
 
-# Create a song
-songData = {
+# Create a SpotifyTrack
+spotify_track = SpotifyTrack.create!(
     title: "Gravity",
     artist: "John Mayer",
     artwork_url: "https://i.scdn.co/image/ab67616d0000b2737af5fdc5ef048a68db62b85f",
-    spotify_id: "3SktMqZmo3M9zbB7oKMIF7",
-    capo: nil,
+    spotify_id: "3SktMqZmo3M9zbB7oKMIF7"
+)
+
+# Create a song
+songData = {
     guitar_type: "Electric",
+    capo: nil,
     notes: "Put a little reverb on it. I'll post links to videos soon!",
     user: user,
+    spotify_track: spotify_track,
     sections_attributes: [
         {
             name: "Intro/Chorus",

--- a/frontend/src/components/search/SearchContainer.js
+++ b/frontend/src/components/search/SearchContainer.js
@@ -49,7 +49,7 @@ class SearchContainer extends Component {
     return (
       <div id='search-container'>
         <SearchForm query={query} handleChange={this.handleChange} />
-        <SearchResults results={results} handleSpotifyData={this.props.handleSpotifyData}/>
+        <SearchResults results={results} handleSpotifyTrack={this.props.handleSpotifyTrack}/>
       </div>
     )
   }

--- a/frontend/src/components/search/SearchResults.js
+++ b/frontend/src/components/search/SearchResults.js
@@ -8,7 +8,7 @@ class SearchResults extends Component {
 
   renderResults = () => {
 
-    const { results, handleSpotifyData } = this.props
+    const { results, handleSpotifyTrack } = this.props
 
     return results.map(result => {
 
@@ -18,7 +18,7 @@ class SearchResults extends Component {
       const artist = result.artists[0].name
 
       return (
-        <ListGroup.Item action as='button' onClick={() => handleSpotifyData(result)} key={result.id}>
+        <ListGroup.Item action as='button' onClick={() => handleSpotifyTrack(result)} key={result.id}>
           <SearchResult artwork_url={artwork_url} title={title} artist={artist} />
         </ListGroup.Item>
       )

--- a/frontend/src/components/songs/ShowSong.js
+++ b/frontend/src/components/songs/ShowSong.js
@@ -10,19 +10,11 @@ class ShowSong extends Component {
     const { songs, match } = this.props
     // Find the song to display
     const song = songs.find(song => song.id === parseInt(match.params.songId))
-    
-    // TODO: This really needs to be handled in the backend. Just doing for now.
-    const spotifyData = {
-      spotify_id: song.spotify_id,
-      title: song.title,
-      artist: song.artist,
-      artwork_url: song.artwork_url
-    }
 
     return (
       <div>
         <h3>Show Song</h3>
-        <SongHeader spotifyData={spotifyData} />
+        <SongHeader spotifyTrack={song.spotify_track} />
       </div>
     )
   }

--- a/frontend/src/components/songs/SongFormContainer.js
+++ b/frontend/src/components/songs/SongFormContainer.js
@@ -4,10 +4,10 @@ import SongHeader from './SongHeader'
 
 
 const SongFormContainer = props => {
-  const { spotifyData, handleSubmit } = props
+  const { spotifyTrack, handleSubmit } = props
   return (
     <div>
-      <SongHeader spotifyData={spotifyData} />
+      <SongHeader spotifyTrack={spotifyTrack} />
       <SongForm handleSubmit={handleSubmit} />
     </div>
   )

--- a/frontend/src/components/songs/SongHeader.js
+++ b/frontend/src/components/songs/SongHeader.js
@@ -4,7 +4,7 @@ import { Row, Col, Image } from 'react-bootstrap'
 
 const SongHeader = props => {
 
-  const { artwork_url, title, artist, spotify_id } = props.spotifyData
+  const { artwork_url, title, artist, spotify_id } = props.spotifyTrack
 
   return (
     <div>

--- a/frontend/src/components/songs/SongsContainer.js
+++ b/frontend/src/components/songs/SongsContainer.js
@@ -5,7 +5,7 @@ import NewSong from './NewSong'
 import ShowSong from './ShowSong'
 
 
-const SongsContainer = props => {
+const SongsContainer = () => {
 
   const { path } = useRouteMatch()
 


### PR DESCRIPTION
The original database design was intended to be simple, but it didn't scale and actually conflated two objects. Specifically, the `Song` model was comprised of both spotify data and user-generated data about how to play the song. This was a bad idea for a number of reasons, the main ones being how that data is used on the frontend and redundancy of data if there are multiple users of the application who use the same spotify track. Thus, these concepts have been decoupled.