### PR TITLE
Consistent Theme

### DIFF
--- a/frontend/src/components/repertoire/RepertoireHeader.js
+++ b/frontend/src/components/repertoire/RepertoireHeader.js
@@ -34,9 +34,9 @@ class RepertoireHeader extends Component {
             <Form.Group>
               <p style={{fontSize: 18}} className="text-muted">Guitar Type</p>
               <ToggleButtonGroup type="radio" name="guitarType" defaultValue={guitarType} onChange={value => this.mockChangeEvent('guitarType', value)}>
-                <ToggleButton value="">Any</ToggleButton>
-                <ToggleButton value="Acoustic">Acoustic</ToggleButton>
-                <ToggleButton value="Electric">Electric</ToggleButton>
+                <ToggleButton variant="dark" value="">Any</ToggleButton>
+                <ToggleButton variant="dark" value="Acoustic">Acoustic</ToggleButton>
+                <ToggleButton variant="dark" value="Electric">Electric</ToggleButton>
               </ToggleButtonGroup>
             </Form.Group>
           </Col>
@@ -44,8 +44,8 @@ class RepertoireHeader extends Component {
             <Form.Group>
               <p style={{fontSize: 18}} className="text-muted">Order By</p>
               <ToggleButtonGroup type="radio" name="orderBy" defaultValue={orderBy} onChange={value => this.mockChangeEvent('orderBy', value)}>
-                <ToggleButton value="title">Title</ToggleButton>
-                <ToggleButton value="artist">Artist</ToggleButton>
+                <ToggleButton variant="dark" value="title">Title</ToggleButton>
+                <ToggleButton variant="dark" value="artist">Artist</ToggleButton>
               </ToggleButtonGroup>{' '}
               <Form.Switch inline id="order-switch" label={ ascending ? 'Ascending' : 'Descending' } onChange={() => this.mockChangeEvent('ascending', !ascending)} />
             </Form.Group>

--- a/frontend/src/components/search/SearchContainer.js
+++ b/frontend/src/components/search/SearchContainer.js
@@ -91,6 +91,13 @@ class SearchContainer extends Component {
       .then(resp => handleResponse(resp, success))
   }
 
+  handleMouseEnter = resultIndex => {
+    // When a user hovers over a result, set the selectedIndex to that result
+    this.setState({
+      selectedIndex: resultIndex
+    })
+  }
+
   render() {
     const { query, results, selectedIndex } = this.state
 
@@ -98,7 +105,7 @@ class SearchContainer extends Component {
       <Container id="search-container" className="bg-white custom-shadow rounded my-4">
         <SearchHeader/>
         <SearchForm query={query} handleChange={this.handleChange} handleKeyDown={this.handleKeyDown}/>
-        <SearchResults results={results} selectedIndex={selectedIndex} handleSpotifyTrack={this.props.handleSpotifyTrack}/>
+        <SearchResults results={results} selectedIndex={selectedIndex} handleMouseEnter={this.handleMouseEnter} handleSpotifyTrack={this.props.handleSpotifyTrack}/>
       </Container>
     )
   }

--- a/frontend/src/components/search/SearchResults.js
+++ b/frontend/src/components/search/SearchResults.js
@@ -7,7 +7,7 @@ class SearchResults extends Component {
 
   renderResults = () => {
 
-    const { results, selectedIndex, handleSpotifyTrack } = this.props
+    const { results, selectedIndex, handleMouseEnter, handleSpotifyTrack } = this.props
 
     return results.map( (result, index) => {
 
@@ -18,7 +18,7 @@ class SearchResults extends Component {
       const displayText = `${title} - ${artist}`
 
       return (
-        <div className="search-result" key={result.id}>
+        <div className="search-result" key={result.id} onMouseEnter={() => handleMouseEnter(index)}>
           <ListGroup.Item active={index === selectedIndex} action as='button' onClick={() => handleSpotifyTrack(result)}>
             <Image rounded src={artwork_url} alt={`${displayText} album artwork`} />
             <span style={{paddingLeft: 20}}>{displayText}</span>

--- a/frontend/src/components/search/search.css
+++ b/frontend/src/components/search/search.css
@@ -18,3 +18,8 @@
 .search-result img {
     height: 35px;
 }
+
+.list-group-item.active {
+    background-color: #292b2c !important;
+    border-color: #292b2c !important;
+}

--- a/frontend/src/components/sessions/LogInForm.js
+++ b/frontend/src/components/sessions/LogInForm.js
@@ -53,7 +53,7 @@ class LogInForm extends Component {
             <Form.Control type="password" name="password" placeholder="Password" value={this.state.password} onChange={this.handleInputChange}/>
           </Form.Group>
           <Container className="mx-auto text-center">
-            <Button variant="primary" type="submit">Submit</Button>
+            <Button variant="dark" type="submit">Submit</Button>
           </Container>
         </Form>
         <p style={{paddingTop: 20, fontSize: "smaller"}}>Don't have an account? <Link to="/signup">Sign Up</Link></p>

--- a/frontend/src/components/sessions/LogInForm.js
+++ b/frontend/src/components/sessions/LogInForm.js
@@ -56,7 +56,7 @@ class LogInForm extends Component {
             <Button variant="dark" type="submit">Submit</Button>
           </Container>
         </Form>
-        <p style={{paddingTop: 20, fontSize: "smaller"}}>Don't have an account? <Link to="/signup">Sign Up</Link></p>
+        <p style={{paddingTop: 20, fontSize: "smaller"}}>Don't have an account? <Link style={{color: 'grey'}} to="/signup">Sign Up</Link></p>
       </Container>
     )
   }

--- a/frontend/src/components/sessions/SignUpForm.js
+++ b/frontend/src/components/sessions/SignUpForm.js
@@ -61,7 +61,7 @@ class SignUpForm extends Component {
             <Form.Control type="password" name="password_confirmation" placeholder="Password Confirmation" value={this.state.password_confirmation} onChange={this.handleInputChange}/>
           </Form.Group>
           <Container className="mx-auto text-center">
-            <Button variant="primary" type="submit">Submit</Button>
+            <Button variant="dark" type="submit">Submit</Button>
           </Container>
         </Form>
         <p style={{paddingTop: 20, fontSize: "smaller"}}>Already have an account? <Link to="/login">Log In</Link></p>

--- a/frontend/src/components/sessions/SignUpForm.js
+++ b/frontend/src/components/sessions/SignUpForm.js
@@ -64,7 +64,7 @@ class SignUpForm extends Component {
             <Button variant="dark" type="submit">Submit</Button>
           </Container>
         </Form>
-        <p style={{paddingTop: 20, fontSize: "smaller"}}>Already have an account? <Link to="/login">Log In</Link></p>
+        <p style={{paddingTop: 20, fontSize: "smaller"}}>Already have an account? <Link style={{color: 'grey'}} to="/login">Log In</Link></p>
       </Container>
     )
   }

--- a/frontend/src/components/songs/ShowSong.js
+++ b/frontend/src/components/songs/ShowSong.js
@@ -80,7 +80,7 @@ class ShowSong extends Component {
           {/* --- SUBMISSION --- */}
           <div style={{marginTop: '5vh', marginBottom: '5vh', textAlign: 'center'}}>
             <LinkContainer to={`/songs/${id}/edit`}>
-              <Button variant="primary">Edit</Button>
+              <Button variant="dark">Edit</Button>
             </LinkContainer>{' '}
             <Button variant="danger" onClick={this.handleDeleteClick}>Delete</Button>
           </div>

--- a/frontend/src/components/songs/ShowSong.js
+++ b/frontend/src/components/songs/ShowSong.js
@@ -70,7 +70,7 @@ class ShowSong extends Component {
           <h3 className="form-heading">Resources</h3>
           <Row className="py-1">
             <Col xs={2} className="right-label text-muted">YouTube</Col>
-            <Col>{ youtube_id ? <YouTube videoId={youtube_id} /> : 'None' }</Col>
+            <Col>{ youtube_id ? <YouTube videoId={youtube_id} /> : null }</Col>
           </Row>
           <Row className="py-1">
             <Col xs={2} className="right-label text-muted">Notes</Col>

--- a/frontend/src/components/songs/SongForm.js
+++ b/frontend/src/components/songs/SongForm.js
@@ -88,7 +88,7 @@ class SongForm extends Component {
             <Col sm={{ span: 10, offset: 2 }}>
               <Button variant="danger" size="sm" onClick={() => this.removeSection(index)}>Remove</Button>{' '}
               {/* Last section gets the "Add Section" button too */}
-              { index === sections.length - 1 ? <Button size="sm" onClick={this.addSection}>Add Section</Button> : null }
+              { index === sections.length - 1 ? <Button variant="dark" size="sm" onClick={this.addSection}>Add Section</Button> : null }
             </Col>
           </Form.Group>
         </div>
@@ -183,7 +183,7 @@ class SongForm extends Component {
           <Form.Group as={Row} style={{marginTop: '5vh', marginBottom: '5vh', textAlign: 'center'}}>
             <Col style={{marginBottom: '5vh'}}>
               <Button variant="secondary" onClick={handleCancel}>Cancel</Button>{' '}
-              <Button type="submit">Save</Button>
+              <Button variant="dark" type="submit">Save</Button>
             </Col>
           </Form.Group>
 


### PR DESCRIPTION
Change bootstrap default primary blue buttons to dark theme to match the brand. Similarly, change the selected search result in Spotify search results list group to have a dark background instead of blue, and make it so that background is applied on mouse hover as well. Also change links on session form to grey instead of blue.