### PR TITLE
Forms with Formik and Yup

### DIFF
--- a/backend/app/controllers/api/v1/sessions_controller.rb
+++ b/backend/app/controllers/api/v1/sessions_controller.rb
@@ -12,7 +12,7 @@ class Api::V1::SessionsController < ApplicationController
                 token: token
             }, status: :created
         else
-            render json: { error: 'Failed to log in', messages: ['Invalid email or password'] }, status: :forbidden
+            render json: { error: 'Failed to log in', message: 'Invalid email or password' }, status: :forbidden
         end
     end
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -4408,6 +4408,11 @@
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
     },
+    "deepmerge": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-2.2.1.tgz",
+      "integrity": "sha512-R9hc1Xa/NOBi9WRVUWg19rl1UB7Tt4kuPd+thNJgFZoxXsTz7ncaPaeIm+40oSGuP33DfMb4sZt1QIGiJzC4EA=="
+    },
     "default-gateway": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/default-gateway/-/default-gateway-4.2.0.tgz",
@@ -5761,6 +5766,11 @@
         }
       }
     },
+    "fn-name": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/fn-name/-/fn-name-3.0.0.tgz",
+      "integrity": "sha512-eNMNr5exLoavuAMhIUVsOKF79SWd/zG104ef6sxBTSw+cZc6BXdQXDvYcGvp0VbxVVSp1XDUNoz7mg1xMtSznA=="
+    },
     "follow-redirects": {
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.11.0.tgz",
@@ -5820,6 +5830,32 @@
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.6",
         "mime-types": "^2.1.12"
+      }
+    },
+    "formik": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/formik/-/formik-2.1.4.tgz",
+      "integrity": "sha512-oKz8S+yQBzuQVSEoxkqqJrKQS5XJASWGVn6mrs+oTWrBoHgByVwwI1qHiVc9GKDpZBU9vAxXYAKz2BvujlwunA==",
+      "requires": {
+        "deepmerge": "^2.1.1",
+        "hoist-non-react-statics": "^3.3.0",
+        "lodash": "^4.17.14",
+        "lodash-es": "^4.17.14",
+        "react-fast-compare": "^2.0.1",
+        "scheduler": "^0.18.0",
+        "tiny-warning": "^1.0.2",
+        "tslib": "^1.10.0"
+      },
+      "dependencies": {
+        "scheduler": {
+          "version": "0.18.0",
+          "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.18.0.tgz",
+          "integrity": "sha512-agTSHR1Nbfi6ulI0kYNK0203joW2Y5W4po4l+v03tOoiJKpTBbxpNhWDvqc/4IcOw+KLmSiQLTasZ4cab2/UWQ==",
+          "requires": {
+            "loose-envify": "^1.1.0",
+            "object-assign": "^4.1.1"
+          }
+        }
       }
     },
     "forwarded": {
@@ -10206,6 +10242,11 @@
         "warning": "^4.0.0"
       }
     },
+    "property-expr": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/property-expr/-/property-expr-2.0.2.tgz",
+      "integrity": "sha512-bc/5ggaYZxNkFKj374aLbEDqVADdYaLcFo8XBkishUWbaAdjlphaBFns9TvRA2pUseVL/wMFmui9X3IdNDU37g=="
+    },
     "proxy-addr": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.6.tgz",
@@ -10650,6 +10691,11 @@
       "version": "6.0.7",
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.7.tgz",
       "integrity": "sha512-TAv1KJFh3RhqxNvhzxj6LeT5NWklP6rDr2a0jaTfsZ5wSZWHOGeqQyejUp3xxLfPt2UpyJEcVQB/zyPcmonNFA=="
+    },
+    "react-fast-compare": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-2.0.4.tgz",
+      "integrity": "sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw=="
     },
     "react-is": {
       "version": "16.13.1",
@@ -12464,6 +12510,11 @@
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="
     },
+    "synchronous-promise": {
+      "version": "2.0.13",
+      "resolved": "https://registry.npmjs.org/synchronous-promise/-/synchronous-promise-2.0.13.tgz",
+      "integrity": "sha512-R9N6uDkVsghHePKh1TEqbnLddO2IY25OcsksyFp/qBe7XYd0PVbKEWxhcdMhpLzE1I6skj5l4aEZ3CRxcbArlA=="
+    },
     "table": {
       "version": "5.4.6",
       "resolved": "https://registry.npmjs.org/table/-/table-5.4.6.tgz",
@@ -12848,6 +12899,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
       "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw=="
+    },
+    "toposort": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/toposort/-/toposort-2.0.2.tgz",
+      "integrity": "sha1-riF2gXXRVZ1IvvNUILL0li8JwzA="
     },
     "tough-cookie": {
       "version": "2.5.0",
@@ -14296,6 +14352,30 @@
         "debug": "^2.6.6",
         "load-script": "^1.0.0",
         "sister": "^3.0.0"
+      }
+    },
+    "yup": {
+      "version": "0.29.1",
+      "resolved": "https://registry.npmjs.org/yup/-/yup-0.29.1.tgz",
+      "integrity": "sha512-U7mPIbgfQWI6M3hZCJdGFrr+U0laG28FxMAKIgNvgl7OtyYuUoc4uy9qCWYHZjh49b8T7Ug8NNDdiMIEytcXrQ==",
+      "requires": {
+        "@babel/runtime": "^7.9.6",
+        "fn-name": "~3.0.0",
+        "lodash": "^4.17.15",
+        "lodash-es": "^4.17.11",
+        "property-expr": "^2.0.2",
+        "synchronous-promise": "^2.0.10",
+        "toposort": "^2.0.2"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.10.2",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.10.2.tgz",
+          "integrity": "sha512-6sF3uQw2ivImfVIl62RZ7MXhO2tap69WeWK57vAaimT6AZbE4FbqjdEJIN1UqoD6wI6B+1n9UiagafH1sxjOtg==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        }
       }
     }
   }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,6 +7,7 @@
     "@testing-library/react": "^9.3.2",
     "@testing-library/user-event": "^7.1.2",
     "bootstrap": "^4.5.0",
+    "formik": "^2.1.4",
     "immutability-helper": "^3.0.2",
     "react": "^16.13.1",
     "react-bootstrap": "^1.0.1",
@@ -17,7 +18,8 @@
     "react-scripts": "3.4.1",
     "react-youtube": "^7.11.2",
     "redux": "^4.0.5",
-    "redux-thunk": "^2.3.0"
+    "redux-thunk": "^2.3.0",
+    "yup": "^0.29.1"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/frontend/src/actions/sessions.js
+++ b/frontend/src/actions/sessions.js
@@ -2,15 +2,15 @@ import { backendURL, handleResponse, setAuthToken, removeAuthToken } from '../ut
 import { setSongs } from './songs'
 
 
-export const signup = (bodyData, callback) => {
+export const signup = (bodyData, handleFailure, redirect) => {
   return dispatch => {
-    sessionRequest('signup', bodyData, callback, dispatch)
+    sessionRequest('signup', bodyData, handleFailure, redirect, dispatch)
   }
 }
 
-export const login = (bodyData, callback) => {
+export const login = (bodyData, handleFailure, redirect) => {
   return dispatch => {
-    sessionRequest('login', bodyData, callback, dispatch)
+    sessionRequest('login', bodyData, handleFailure, redirect, dispatch)
   }
 }
 
@@ -23,7 +23,7 @@ export const setLoggedInUser = user => {
   return { type: 'LOG_IN_USER', user }
 }
 
-const sessionRequest = (endpoint, bodyData, callback, dispatch) => {
+const sessionRequest = (endpoint, bodyData, handleFailure, redirect, dispatch) => {
 
   const req = {
     method: 'POST',
@@ -39,12 +39,12 @@ const sessionRequest = (endpoint, bodyData, callback, dispatch) => {
     dispatch(setLoggedInUser(userData.user))  // Store user's data in redux
     dispatch(setSongs(userData.songs))        // Store the user's songs in redux
     setAuthToken(userData.token)              // Save the user's auth token in localStorage
-    if (!!callback) { callback() }            // Exexcute the callback if necessary
+    if (!!redirect) { redirect() }            // Exexcute the redirect callback if applicable
   }
 
   // Fall back on the generic API failure of `handleResponse`
   fetch(`${backendURL}/${endpoint}`, req)
-    .then(resp => handleResponse(resp, success))
+    .then(resp => handleResponse(resp, success, handleFailure))
     .catch(err => {
       window.alert(`Unknown Error: ${err}`)
     })

--- a/frontend/src/components/sessions/LogInForm.js
+++ b/frontend/src/components/sessions/LogInForm.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react'
+import { Formik } from 'formik'
 import { Link, withRouter } from 'react-router-dom'
 import { connect } from 'react-redux'
 import { Button, Container, Form } from 'react-bootstrap'
@@ -7,24 +8,7 @@ import { login } from '../../actions/sessions'
 
 class LogInForm extends Component {
   
-  constructor(props) {
-    super(props)
-    this.state = {
-      email: '',
-      password: ''
-    }
-  }
-
-  handleInputChange = event => {
-    const { name, value } = event.target
-    this.setState({
-      [name]: value
-    });
-  }
-
-  handleSubmit = event => {
-    // Prevent default form submission
-    event.preventDefault()
+  handleSubmit = values => {
 
     // Grab `history` and `location` for managing login redirects, and the `login` action creator
     const { history, location, login } = this.props
@@ -35,28 +19,49 @@ class LogInForm extends Component {
 
     // Call the login action creator with a callback to send the user to the homepage after successful login
     login(
-      this.state,
+      values,
       () => history.replace(from)
     )
   }
   
   render() {
 
+    // TODO: Upon submission, dump server errors back here somewhere!!
+    // e.g. <Form.Control.Feedback type="invalid">{errors.general}</Form.Control.Feedback>
+
     return (
       <Container className="col-10 text-center">
         <h1 className="session-form-header">Log In</h1>
-        <Form onSubmit={this.handleSubmit}>
-          <Form.Group>
-            <Form.Control required type="email" name="email" placeholder="Email" value={this.state.email} onChange={this.handleInputChange}/>
-          </Form.Group>
-          <Form.Group>
-            <Form.Control required type="password" name="password" placeholder="Password" value={this.state.password} onChange={this.handleInputChange}/>
-          </Form.Group>
-          <Container className="mx-auto text-center">
-            <Button variant="dark" type="submit">Submit</Button>
-          </Container>
-        </Form>
+
+        {/* Begin form, controlled by Formik */}
+        <Formik 
+          initialValues={{ email: '', password: '' }}
+          onSubmit={this.handleSubmit}
+        >
+        {
+          ({
+            handleSubmit,
+            handleChange,
+            values,
+            errors
+          }) => (
+            <Form noValidate onSubmit={handleSubmit}>
+              <Form.Group>
+                <Form.Control type="email" name="email" placeholder="Email" value={values.email} onChange={handleChange}/>
+              </Form.Group>
+              <Form.Group>
+                <Form.Control type="password" name="password" placeholder="Password" value={values.password} onChange={handleChange}/>
+              </Form.Group>
+              <Container className="mx-auto text-center">
+                <Button variant="dark" type="submit">Submit</Button>
+              </Container>
+            </Form>
+          )
+        }
+        </Formik>  
+        
         <p style={{paddingTop: 20, fontSize: "smaller"}}>Don't have an account? <Link style={{color: 'grey'}} to="/signup">Sign Up</Link></p>
+      
       </Container>
     )
   }

--- a/frontend/src/components/sessions/LogInForm.js
+++ b/frontend/src/components/sessions/LogInForm.js
@@ -8,7 +8,7 @@ import { login } from '../../actions/sessions'
 
 class LogInForm extends Component {
   
-  handleSubmit = values => {
+  handleSubmit = (values, { setSubmitting, setStatus, resetForm }) => {
 
     // Grab `history` and `location` for managing login redirects, and the `login` action creator
     const { history, location, login } = this.props
@@ -17,10 +17,15 @@ class LogInForm extends Component {
     // Note destructuring, so `from` variable will be an object with top-level key of `pathname` regardless.
     const { from } = location.state || { from: { pathname: '/' } }
 
-    // Call the login action creator with a callback to send the user to the homepage after successful login
+    // Call the login action creator. Render an error from the server on failure or redirect on success.
     login(
       values,
-      () => history.replace(from)
+      error => {
+        resetForm()
+        setStatus({ generalError: error.status >= 500 ? error.error : error.message }) 
+        setSubmitting(false)
+      },
+      () => { history.replace(from) }
     )
   }
   
@@ -43,9 +48,10 @@ class LogInForm extends Component {
             handleSubmit,
             handleChange,
             values,
-            errors
+            status  // This is where generalError from the backend will get passed (in the sumbit handler)
           }) => (
             <Form noValidate onSubmit={handleSubmit}>
+              { status && status.generalError && <p style={{color: 'red'}}>{status.generalError}</p> }
               <Form.Group>
                 <Form.Control type="email" name="email" placeholder="Email" value={values.email} onChange={handleChange}/>
               </Form.Group>

--- a/frontend/src/components/sessions/SignUpForm.js
+++ b/frontend/src/components/sessions/SignUpForm.js
@@ -1,4 +1,6 @@
 import React, { Component } from 'react'
+import { Formik } from 'formik'
+import { object, string } from 'yup'
 import { Link, withRouter } from 'react-router-dom'
 import { connect } from 'react-redux'
 import { Button, Container, Form } from 'react-bootstrap'
@@ -18,23 +20,13 @@ class SignUpForm extends Component {
     }
   }
 
-  handleInputChange = event => {
-    const { name, value } = event.target
-    this.setState({
-      [name]: value
-    });
-  }
-
-  handleSubmit = event => {
-    // Prevent default form submission
-    event.preventDefault()
-
+  handleSubmit = values => {
     // Grab `history` for managing login redirects, and the `sigup` action creator
     const { history, signup } = this.props
 
     // Call the signup action creator with a callback to send the user to the homepage after success
     signup(
-      this.state,
+      values,
       () => history.push('/')
     )
   }
@@ -44,26 +36,55 @@ class SignUpForm extends Component {
     return (
       <Container className="col-10 text-center my-3">
         <h1 className="session-form-header">Sign Up</h1>
-        <Form onSubmit={this.handleSubmit}>
-          <Form.Group>
-            <Form.Control required type="text" name="first_name" placeholder="First Name" value={this.state.first_name} onChange={this.handleInputChange}/>
-          </Form.Group>
-          <Form.Group>
-            <Form.Control required type="text" name="last_name" placeholder="Last Name" value={this.state.last_name} onChange={this.handleInputChange}/>
-          </Form.Group>
-          <Form.Group>
-            <Form.Control required type="email" name="email" placeholder="Email" value={this.state.email} onChange={this.handleInputChange}/>
-          </Form.Group>
-          <Form.Group>
-            <Form.Control required type="password" name="password" placeholder="Password" value={this.state.password} onChange={this.handleInputChange}/>
-          </Form.Group>
-          <Form.Group>
-            <Form.Control required type="password" name="password_confirmation" placeholder="Password Confirmation" value={this.state.password_confirmation} onChange={this.handleInputChange}/>
-          </Form.Group>
-          <Container className="mx-auto text-center">
-            <Button variant="dark" type="submit">Submit</Button>
-          </Container>
-        </Form>
+        
+        <Formik
+          initialValues={{first_name: '', last_name: '', email: '', password: '', password_confirmation: ''}}
+          validationSchema={object({
+            first_name: string().required('Required'),
+            last_name: string().required('Required'),
+            email: string().required('Required').email('Invalid email address'),
+            password: string().required('Required').min(8, 'Must be at least 8 characters'),
+            password_confirmation: string().required('Required').min(8, 'Must be at least 8 characters')
+          })}
+          onSubmit={this.handleSubmit}
+        >
+        {
+          ({
+            handleSubmit,
+            handleChange,
+            handleBlur,
+            values,
+            errors,
+            touched
+          }) => (
+            <Form noValidate onSubmit={handleSubmit}>
+              <Form.Group>
+                <Form.Control required type="text" name="first_name" placeholder="First Name" value={values.first_name} onChange={handleChange} onBlur={handleBlur} isInvalid={touched.first_name && !!errors.first_name}/>
+                <Form.Control.Feedback type="invalid">{errors.first_name}</Form.Control.Feedback>
+              </Form.Group>
+              <Form.Group>
+                <Form.Control required type="text" name="last_name" placeholder="Last Name" value={values.last_name} onChange={handleChange} onBlur={handleBlur} isInvalid={touched.last_name && !!errors.last_name}/>
+                <Form.Control.Feedback type="invalid">{errors.last_name}</Form.Control.Feedback>
+              </Form.Group>
+              <Form.Group>
+                <Form.Control required type="email" name="email" placeholder="Email" value={values.email} onChange={handleChange} onBlur={handleBlur} isInvalid={touched.email && !!errors.email}/>
+                <Form.Control.Feedback type="invalid">{errors.email}</Form.Control.Feedback>
+              </Form.Group>
+              <Form.Group>
+                <Form.Control required type="password" name="password" placeholder="Password" value={values.password} onChange={handleChange} onBlur={handleBlur} isInvalid={touched.password && !!errors.password}/>
+                <Form.Control.Feedback type="invalid">{errors.password}</Form.Control.Feedback>
+              </Form.Group>
+              <Form.Group>
+                <Form.Control required type="password" name="password_confirmation" placeholder="Password Confirmation" value={values.password_confirmation} onChange={handleChange} onBlur={handleBlur} isInvalid={touched.password_confirmation && !!errors.password_confirmation}/>
+                <Form.Control.Feedback type="invalid">{errors.password_confirmation}</Form.Control.Feedback>
+              </Form.Group>
+              <Container className="mx-auto text-center">
+                <Button variant="dark" type="submit">Submit</Button>
+              </Container>
+            </Form>
+          )
+        }
+        </Formik>
         <p style={{paddingTop: 20, fontSize: "smaller"}}>Already have an account? <Link style={{color: 'grey'}} to="/login">Log In</Link></p>
       </Container>
     )

--- a/frontend/src/components/songs/EditSong.js
+++ b/frontend/src/components/songs/EditSong.js
@@ -25,14 +25,12 @@ class EditSong extends Component {
     }
   }
 
-  handleSubmit = (event, formData) => {
-    event.preventDefault()
-  
+  handleSubmit = values => {
     const { history, updateSongAsync, song } = this.props
     
     updateSongAsync(
       song.id,
-      formData,
+      values,
       songId => { history.push(`/songs/${songId}`) },
       error => { this.setState({ errors: error.messages, showErrors: true }) }  // On failure, update this component state with the error messages to be displayed
     )

--- a/frontend/src/components/songs/NewSongContainer.js
+++ b/frontend/src/components/songs/NewSongContainer.js
@@ -43,13 +43,11 @@ class NewSongContainer extends Component {
   }
 
   // Form submit action that is specific to creating a new song (must pass spotify data and form data to backend)
-  handleSubmit = (event, formData) => {
-    event.preventDefault()
-    
+  handleSubmit = values => {    
     const { addSongAsync, history } = this.props
 
     addSongAsync(
-      formData,
+      values,
       this.state.spotifyTrack,
       songId => { history.push(`/songs/${songId}`) },
       error => { this.setState({ errors: error.messages, showErrors: true }) }  // On failure, update this component state with the error messages to be displayed

--- a/frontend/src/components/songs/SongForm.js
+++ b/frontend/src/components/songs/SongForm.js
@@ -1,18 +1,17 @@
 import React, { Component } from 'react'
 import { Button, Form, Row, Col, Container } from 'react-bootstrap'
-import update from 'immutability-helper'
+import { Formik, FieldArray } from 'formik'
+import { object, array, string, boolean } from 'yup'
 
 
 class SongForm extends Component {
-  
-  constructor(props) {
-    super(props)
 
+  getInitialFormValues = () => {
     // Initialze state with either the provided song's or a new song's data
-    const initialSong = props.song || this.songFactory()
+    const initialSong = this.props.song || this.songFactory()
     const { guitar_type, capo, strumming, sections, youtube_id, notes } = initialSong
-
-    this.state = {
+    
+    return {
       guitar_type,
       capo,
       strumming,
@@ -21,7 +20,7 @@ class SongForm extends Component {
       notes,
     }
   }
-  
+
   sectionFactory = (name='', chords='') => {
     return { name, chords }
   }
@@ -30,42 +29,42 @@ class SongForm extends Component {
     return { guitar_type, capo, strumming, sections, youtube_id, notes }
   }
 
-  handleChange = event => {
-    const { name, value } = event.target
-    this.setState({
-      [name]: value
-    })
+  sectionFieldInvalid = (fieldName, sectionIndex, sectionsTouched, sectionsErrors) => {
+    return !!(
+      this.sectionFieldTouched(fieldName, sectionIndex, sectionsTouched) &&
+      this.sectionFieldErrors(fieldName, sectionIndex, sectionsErrors)
+    )
   }
 
-  handleSectionChange = (event, index) => {
-    
-    const { name, value } = event.target
-    
-    // Update the state for the section at the correct index of the sections array. 
-    // Use immutability helper to simplify the update while not mutating the state.
-    this.setState(prevState => {
-      // Update the prevState's section key at the specified index 
-      return update(
-        prevState, 
-        { sections: { [index]: { [name]: {$set: value} } }}
-      )
-    })
+  sectionFieldTouched = (fieldName, sectionIndex, sectionsTouched) => {
+    return sectionsTouched && sectionsTouched[sectionIndex] && sectionsTouched[sectionIndex][fieldName]
   }
 
-  renderSections = () => {
+  sectionFieldErrors = (fieldName, sectionIndex, sectionsErrors) => {
+    return sectionsErrors && sectionsErrors[sectionIndex] && sectionsErrors[sectionIndex][fieldName]
+  }
 
-    const { sections } = this.state
+  renderSections = ({ push, replace, form }) => {
+
+    // Extract relevant methods and data from the `form` object
+    const { 
+      handleChange, 
+      handleBlur, 
+      values: { sections },
+      errors: { sections: sectionsErrors }, 
+      touched: { sections: sectionsTouched}
+    } = form
 
     // Count all sections that do not have a `_destroy: true` key-value pair.
     // This is required due to how rails protects nested objects from being destroyed.
-    const numSections = sections.reduce((count, section) => !section._destroy ? ++count : count, 0)
+    const numSectionsToRender = sections.reduce((count, section) => !section._destroy ? ++count : count, 0)
 
-    // If there are no sections, display the button to add one
-    if ( numSections === 0 ) {
+    // If there are no sections to render display the button to add one
+    if ( numSectionsToRender === 0 ) {
       return (
         <Form.Group as={Row}>
           <Col sm={{ span: 10, offset: 2 }}>
-            <Button size="sm" onClick={this.addSection}>Add Section</Button>
+            <Button size="sm" onClick={() => push( this.sectionFactory() )}>Add Section</Button>
           </Col>
         </Form.Group>
       )
@@ -89,20 +88,22 @@ class SongForm extends Component {
           <Form.Group as={Row}>
             <Form.Label column sm={2} className="right-label text-muted">Name</Form.Label>
             <Col sm={4}>
-              <Form.Control required name="name" type="text" placeholder="e.g. Chorus" value={section.name} onChange={event => this.handleSectionChange(event, index)}/>
+              <Form.Control name={`sections.${index}.name`} type="text" placeholder="e.g. Chorus" value={section.name} onChange={handleChange} onBlur={handleBlur} isInvalid={ this.sectionFieldInvalid('name', index, sectionsTouched, sectionsErrors) }/>
+              <Form.Control.Feedback type="invalid">{this.sectionFieldErrors('name', index, sectionsErrors)}</Form.Control.Feedback>
             </Col>
           </Form.Group>
           <Form.Group as={Row}>
             <Form.Label column sm={2} className="right-label text-muted">Chords</Form.Label>
             <Col sm={6}>
-              <Form.Control required name="chords" type="text" placeholder="e.g. Em C G D" value={section.chords} onChange={event => this.handleSectionChange(event, index)}/>
+              <Form.Control name={`sections.${index}.chords`} type="text" placeholder="e.g. Em C G D" value={section.chords} onChange={handleChange} onBlur={handleBlur} isInvalid={ this.sectionFieldInvalid('chords', index, sectionsTouched, sectionsErrors) }/>
+              <Form.Control.Feedback type="invalid">{this.sectionFieldErrors('chords', index, sectionsErrors)}</Form.Control.Feedback>
             </Col>
           </Form.Group>
           <Form.Group as={Row}>
             <Col sm={{ span: 10, offset: 2 }}>
-              <Button variant="danger" size="sm" onClick={() => this.removeSection(index)}>Remove</Button>{' '}
+              <Button variant="danger" size="sm" onClick={() => this.removeSection(section, index, replace)}>Remove</Button>{' '}
               {/* The last rendered section gets the "Add Section" button */}
-              { renderedSections === numSections ? <Button variant="dark" size="sm" onClick={this.addSection}>Add Section</Button> : null }
+              { renderedSections === numSectionsToRender ? <Button variant="dark" size="sm" onClick={() => push( this.sectionFactory() )}>Add Section</Button> : null }
             </Col>
           </Form.Group>
         </div>
@@ -110,99 +111,120 @@ class SongForm extends Component {
     })
   }
 
-  addSection = () => {
-    // Update the state to show another section. Use immutability helper to simplify the update while not mutating the state.
-    this.setState(prevState => {
-      return update(
-        prevState, 
-        {sections: {$push: [this.sectionFactory()] }}
-      )
-    })
-  }
-
-  removeSection = index => {
-    // Update the state to add a `_destroy: true` key-value pair to the section at position `index`.
-    // Again, this is due to how rails handles nested object destruction.
-    this.setState(prevState => {
-      return {
-        sections: prevState.sections.map( (section, i) => i === index ? { ...section, _destroy: true } : section )
-      }
-    })
+  removeSection = (section, index, replace) => {  
+    // Add a `_destroy: true` key-value pair to the section (for rails nested deletion purposes), and then call the
+    // Formik arrayHelper.replace() method to update the section in the array of values.
+    const updatedSection = {
+      ...section,
+      _destroy: true
+    }
+    
+    replace(index, updatedSection)
   }
 
   render() {
     
     const { handleCancel, handleSubmit } = this.props
-    const { guitar_type, capo, strumming, notes, youtube_id } = this.state
 
     return (
-
       <Container className="bg-white custom-shadow rounded" style={{marginBottom: '5vh', paddingLeft: '3vw'}}>
-        <Form onSubmit={event => handleSubmit(event, this.state)}>
+        
+        <Formik
+          initialValues={this.getInitialFormValues()}
+          validationSchema={object({
+            sections: array().of(object({
+              _destroy: boolean(),
+              name: string().trim().when('_destroy', {
+                is: undefined,
+                then: string().required('Required')
+              }),
+              chords: string().trim().when('_destroy', {
+                is: undefined,
+                then: string().required('Required')
+              })
+            }))
+          })}
+          onSubmit={handleSubmit}
+        >
+        {
+          ({
+            handleSubmit,
+            handleChange,
+            handleBlur,
+            values,
+            errors,
+            touched,
+            status  // This is where generalErrors from the backend will get passed (in the sumbit handler)
+          }) => (
+            <Form onSubmit={handleSubmit}>
 
-          {/* --- SONG INFO --- */}
-          <h3 className="form-heading" style={{paddingTop: '3vh'}}>Song Info</h3>
+              {/* --- SONG INFO --- */}
+              <h3 className="form-heading" style={{paddingTop: '3vh'}}>Song Info</h3>
 
-          {/* Guitar Type */}
-          <fieldset>
-            <Form.Group as={Row} onChange={this.handleChange}>
-              <Form.Label as="legend" column sm={2} className="right-label text-muted">Guitar</Form.Label>
-              <Col>
-                <Form.Check inline type="radio" name="guitar_type" label="Any" value="" checked={!guitar_type} onChange={this.handleChange}/>
-                <Form.Check inline type="radio" name="guitar_type" label="Acoustic" value="Acoustic" checked={guitar_type === 'Acoustic'} onChange={this.handleChange}/>
-                <Form.Check inline type="radio" name="guitar_type" label="Electric" value="Electric" checked={guitar_type === 'Electric'} onChange={this.handleChange}/>
-              </Col>
-            </Form.Group>
-          </fieldset>
+              {/* Guitar Type */}
+              <fieldset>
+                <Form.Group as={Row} onChange={handleChange}>
+                  <Form.Label as="legend" column sm={2} className="right-label text-muted">Guitar</Form.Label>
+                  <Col>
+                    <Form.Check inline type="radio" name="guitar_type" label="Any" value="" checked={!values.guitar_type} onChange={handleChange}/>
+                    <Form.Check inline type="radio" name="guitar_type" label="Acoustic" value="Acoustic" checked={values.guitar_type === 'Acoustic'} onChange={handleChange}/>
+                    <Form.Check inline type="radio" name="guitar_type" label="Electric" value="Electric" checked={values.guitar_type === 'Electric'} onChange={handleChange}/>
+                  </Col>
+                </Form.Group>
+              </fieldset>
 
-          {/* Capo */}
-          <Form.Group as={Row}>
-            <Form.Label column sm={2} className="right-label text-muted">Capo</Form.Label>
-            <Col sm={1}>
-              <Form.Control name="capo" type="number" value={capo} onChange={this.handleChange}/>
-            </Col>
-          </Form.Group>
+              {/* Capo */}
+              <Form.Group as={Row}>
+                <Form.Label column sm={2} className="right-label text-muted">Capo</Form.Label>
+                <Col sm={1}>
+                  <Form.Control name="capo" type="number" value={values.capo} onChange={handleChange} onBlur={handleBlur}/>
+                </Col>
+              </Form.Group>
 
-          {/* Strumming */}
-          <Form.Group as={Row}>
-            <Form.Label column sm={2} className="right-label text-muted">Strumming</Form.Label>
-            <Col sm={5}>
-              <Form.Control name="strumming" type="text" placeholder="e.g. D DU UDU" value={strumming} onChange={this.handleChange}/>
-            </Col>
-          </Form.Group>
+              {/* Strumming */}
+              <Form.Group as={Row}>
+                <Form.Label column sm={2} className="right-label text-muted">Strumming</Form.Label>
+                <Col sm={5}>
+                  <Form.Control name="strumming" type="text" placeholder="e.g. D DU UDU" value={values.strumming} onChange={handleChange} onBlur={handleBlur}/>
+                </Col>
+              </Form.Group>
 
-          {/* --- SECTIONS --- */}
-          <h3 className="form-heading">Sections</h3>
-          {this.renderSections()}
-          
-          {/* --- RESOURCES --- */}
-          <h3 className="form-heading">Resources</h3>
-          {/* Youtube */}
-          <Form.Group as={Row}>
-            <Form.Label column sm={2} className="right-label text-muted">YouTube ID</Form.Label>
-            <Col sm={5}>
-              <Form.Control name="youtube_id" type="text" placeholder="e.g. 3_yOc3VDU5I" value={youtube_id} onChange={this.handleChange}/>
-              <Form.Text className="text-muted">Ex: https://www.youtube.com/watch?v=<b>3_yOc3VDU5I</b></Form.Text>
-            </Col>
-          </Form.Group>
+              {/* --- SECTIONS --- */}
+              <h3 className="form-heading">Sections</h3>
+              <FieldArray name="sections" render={this.renderSections}/>
 
-          {/* Notes */}
-          <Form.Group as={Row}>
-            <Form.Label column sm={2} className="right-label text-muted">Notes</Form.Label>
-            <Col sm={9}>
-              <Form.Control as="textarea" rows="5" placeholder="Song notes..." name="notes" value={notes} onChange={this.handleChange}/>
-            </Col>
-          </Form.Group>
+              {/* --- RESOURCES --- */}
+              <h3 className="form-heading">Resources</h3>
+              {/* Youtube */}
+              <Form.Group as={Row}>
+                <Form.Label column sm={2} className="right-label text-muted">YouTube ID</Form.Label>
+                <Col sm={5}>
+                  <Form.Control name="youtube_id" type="text" placeholder="e.g. 3_yOc3VDU5I" value={values.youtube_id} onChange={handleChange} onBlur={handleBlur}/>
+                  <Form.Text className="text-muted">Ex: https://www.youtube.com/watch?v=<b>3_yOc3VDU5I</b></Form.Text>
+                </Col>
+              </Form.Group>
 
-          {/* --- SUBMISSION --- */}
-          <Form.Group as={Row} style={{marginTop: '5vh', marginBottom: '5vh', textAlign: 'center'}}>
-            <Col style={{marginBottom: '5vh'}}>
-              <Button variant="secondary" onClick={handleCancel}>Cancel</Button>{' '}
-              <Button variant="dark" type="submit">Save</Button>
-            </Col>
-          </Form.Group>
+              {/* Notes */}
+              <Form.Group as={Row}>
+                <Form.Label column sm={2} className="right-label text-muted">Notes</Form.Label>
+                <Col sm={9}>
+                  <Form.Control as="textarea" rows="5" placeholder="Song notes..." name="notes" value={values.notes} onChange={handleChange} onBlur={handleBlur}/>
+                </Col>
+              </Form.Group>
 
-        </Form>
+              {/* --- SUBMISSION --- */}
+              <Form.Group as={Row} style={{marginTop: '5vh', marginBottom: '5vh', textAlign: 'center'}}>
+                <Col style={{marginBottom: '5vh'}}>
+                  <Button variant="secondary" onClick={handleCancel}>Cancel</Button>{' '}
+                  <Button variant="dark" type="submit">Save</Button>
+                </Col>
+              </Form.Group>
+
+            </Form>
+          )
+        }
+        </Formik>
+
       </Container>
     )
   }

--- a/frontend/src/components/songs/SongForm.js
+++ b/frontend/src/components/songs/SongForm.js
@@ -7,7 +7,7 @@ import { object, array, string, boolean } from 'yup'
 class SongForm extends Component {
 
   getInitialFormValues = () => {
-    // Initialze state with either the provided song's or a new song's data
+    // Initialze the form data with either the provided song or a new one.
     const initialSong = this.props.song || this.songFactory()
     const { guitar_type, capo, strumming, sections, youtube_id, notes } = initialSong
     
@@ -22,14 +22,17 @@ class SongForm extends Component {
   }
 
   sectionFactory = (name='', chords='') => {
+    // Create an object representing a new section
     return { name, chords }
   }
 
   songFactory = (guitar_type='', capo='', strumming='', sections=[ this.sectionFactory() ], youtube_id='', notes='') => {
+    // Create an object representing a new song
     return { guitar_type, capo, strumming, sections, youtube_id, notes }
   }
 
   sectionFieldInvalid = (fieldName, sectionIndex, sectionsTouched, sectionsErrors) => {
+    // Check whether a given field of a section is invalid, meaning it has been touched and has validation errors.
     return !!(
       this.sectionFieldTouched(fieldName, sectionIndex, sectionsTouched) &&
       this.sectionFieldErrors(fieldName, sectionIndex, sectionsErrors)
@@ -37,16 +40,21 @@ class SongForm extends Component {
   }
 
   sectionFieldTouched = (fieldName, sectionIndex, sectionsTouched) => {
+    // Check whether a given field of a section has been touched (using Formik's tracking)
     return sectionsTouched && sectionsTouched[sectionIndex] && sectionsTouched[sectionIndex][fieldName]
   }
 
   sectionFieldErrors = (fieldName, sectionIndex, sectionsErrors) => {
+    // Check whether a given field of a section has errors (checking against Formik/Yup validation)
     return sectionsErrors && sectionsErrors[sectionIndex] && sectionsErrors[sectionIndex][fieldName]
   }
 
   renderSections = ({ push, replace, form }) => {
+    // Render the variable number of sections in the form. There is some fancy logic in here due to the fact that
+    // Rails requires nested objects to be POSTed with a `_destroy: true` key in order to delete them from a parent object.
+    // Thus we need to hold onto all sections, but we need to only display the ones without this special property.
 
-    // Extract relevant methods and data from the `form` object
+    // Extract relevant methods and data from the Formik `form` object
     const { 
       handleChange, 
       handleBlur, 
@@ -59,7 +67,7 @@ class SongForm extends Component {
     // This is required due to how rails protects nested objects from being destroyed.
     const numSectionsToRender = sections.reduce((count, section) => !section._destroy ? ++count : count, 0)
 
-    // If there are no sections to render display the button to add one
+    // If there are no sections to render, display the button to add one. Then we're done.
     if ( numSectionsToRender === 0 ) {
       return (
         <Form.Group as={Row}>
@@ -70,9 +78,10 @@ class SongForm extends Component {
       )
     }
 
-    // Counter for the number of sections that have been rendered thus far. Used for determining where to put the "Add Section" button
+    // Counter for the number of sections that have been rendered thus far. Used for determining where to put the "Add Section" button.
     let renderedSections = 0
 
+    // Render the sections
     return sections.map((section, index) => {
 
       // Do not render sections that are slated for desctruction. This tracking is necessary for rails purposes.
@@ -80,7 +89,7 @@ class SongForm extends Component {
         return null
       }
 
-      // Increment the rendered sections counter and render the section
+      // Increment the rendered sections counter and render the section that is slated for display.
       renderedSections++
       return (
         <div key={index}>
@@ -113,7 +122,7 @@ class SongForm extends Component {
 
   removeSection = (section, index, replace) => {  
     // Add a `_destroy: true` key-value pair to the section (for rails nested deletion purposes), and then call the
-    // Formik arrayHelper.replace() method to update the section in the array of values.
+    // Formik `arrayHelper.replace()` method to update the section in the array of values.
     const updatedSection = {
       ...section,
       _destroy: true
@@ -123,9 +132,9 @@ class SongForm extends Component {
   }
 
   render() {
-    
     const { handleCancel, handleSubmit } = this.props
 
+    // Render the form with Formik control and Yup validation
     return (
       <Container className="bg-white custom-shadow rounded" style={{marginBottom: '5vh', paddingLeft: '3vw'}}>
         
@@ -151,10 +160,7 @@ class SongForm extends Component {
             handleSubmit,
             handleChange,
             handleBlur,
-            values,
-            errors,
-            touched,
-            status  // This is where generalErrors from the backend will get passed (in the sumbit handler)
+            values
           }) => (
             <Form onSubmit={handleSubmit}>
 


### PR DESCRIPTION
This PR is a big step for form control, validation, and UX! 🎉

Integrates [Formik](https://jaredpalmer.com/formik/) with the existing Bootstrap forms in the app (login, signup, create/edit song). This, coupled with [Yup](https://github.com/jquense/yup) means that there is great client-side form validation for these forms, including highlighting of fields, etc.

Server-side validation is still the same as it was in previous PRs (but with the addition of integrating backend messages in session forms), but now is relied upon less as the frontend screens some of that before it ever makes it to the server.