### PR TITLE
Song Privacy

### DIFF
--- a/backend/app/controllers/application_controller.rb
+++ b/backend/app/controllers/application_controller.rb
@@ -39,12 +39,14 @@ class ApplicationController < ActionController::API
 
     def authorized
         # A filter for checking that a valid user is logged in before an action
-        render json: { error: 'Unauthorized', messages: ['Unauthorized. Please Log In.'] }, status: :unauthorized unless logged_in?
+        unless logged_in?
+            render json: { error: 'Unauthorized', messages: ['Unauthorized. Please Log In.'] }, status: :unauthorized
+        end
     end
 
-    def authorized_user
+    def preview_mode
         # A filter that prevents the special read-only preview user from editing data.
-        if !@user || @user.email == 'johndoe@fake.com'
+        if @user.email == 'johndoe@fake.com'
             render json: { error: 'Unauthorized', messages: ["Preview mode is read-only!"]}, status: :unauthorized
         end
     end

--- a/frontend/src/components/NotFound.js
+++ b/frontend/src/components/NotFound.js
@@ -1,0 +1,21 @@
+import React, { Component } from 'react'
+import { Container, Image } from 'react-bootstrap'
+import setlistLogo from '../SetlistLogo.png'
+
+
+class NotFound extends Component {
+  
+  render() {
+    return (
+      <Container>
+        <h4 className="m-5">We couldn't find that page.</h4>
+        <Image style={{maxWidth: '25%'}} src={setlistLogo} alt="setlist-logo" />
+        <h6 className="m-5">Is your amp plugged in?</h6>
+      </Container>
+    )
+  }
+
+}
+
+
+export default NotFound

--- a/frontend/src/components/NotFound.js
+++ b/frontend/src/components/NotFound.js
@@ -7,7 +7,7 @@ class NotFound extends Component {
   
   render() {
     return (
-      <Container>
+      <Container className="py-1">
         <h4 className="m-5">We couldn't find that page.</h4>
         <Image style={{maxWidth: '25%'}} src={setlistLogo} alt="setlist-logo" />
         <h6 className="m-5">Is your amp plugged in?</h6>

--- a/frontend/src/components/layout/MainDisplay.js
+++ b/frontend/src/components/layout/MainDisplay.js
@@ -10,6 +10,7 @@ import SongsContainer from '../songs/SongsContainer'
 import { logout } from '../../actions/sessions'
 import { mapUserToProps } from '../../utils'
 import './layout.css'
+import NotFound from '../NotFound'
 
 
 const MainDisplay = props => {
@@ -39,6 +40,9 @@ const MainDisplay = props => {
         <PrivateRoute path='/repertoire'>
           <RepertoireContainer/>
         </PrivateRoute>
+        <Route path="*">
+          <NotFound/>
+        </Route>
       </Switch>
 
     </div>

--- a/frontend/src/components/layout/MainDisplay.js
+++ b/frontend/src/components/layout/MainDisplay.js
@@ -37,7 +37,7 @@ const MainDisplay = props => {
         <PrivateRoute path='/songs'>
           <SongsContainer/>
         </PrivateRoute>
-        <PrivateRoute path='/repertoire'>
+        <PrivateRoute exact path='/repertoire'>
           <RepertoireContainer/>
         </PrivateRoute>
         <Route path="*">

--- a/frontend/src/components/songs/ShowSongContainer.js
+++ b/frontend/src/components/songs/ShowSongContainer.js
@@ -4,6 +4,7 @@ import { Container } from 'react-bootstrap'
 import { useParams } from 'react-router-dom'
 import { mapSongsToProps } from '../../utils'
 import ShowSong from './ShowSong'
+import NotFound from '../NotFound'
 
 
 const ShowSongContainer = props => {
@@ -14,11 +15,17 @@ const ShowSongContainer = props => {
   const { songId } = useParams()
   const song = songs.find(song => song.id === parseInt(songId))
   
-  return (
-    <Container id="show-song-container" className="py-1">
-      <ShowSong song={song}/>
-    </Container>
-  )
+  // Render the song if it's found in redux store. 
+  // If the song isn't found, it either doesn't exist or it belongs to a different user.
+  if ( !!song ) {
+    return (
+      <Container id="show-song-container" className="py-1">
+        <ShowSong song={song}/>
+      </Container>
+    )
+  } else {
+    return <NotFound/>
+  }
 }
 
 


### PR DESCRIPTION
On the frontend, add a custom NotFound component (basically a 404 page) for when a user tries to visit an invalid route OR a route that they are not authorized to see. This is really just songs that are owned by other users.

On the backend, do not allow users to touch the data of songs that they do not own.